### PR TITLE
Replace deprecated pkg_resources with importlib.metadata

### DIFF
--- a/ninfo/__init__.py
+++ b/ninfo/__init__.py
@@ -1,6 +1,6 @@
 from pkg_resources import iter_entry_points
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 import memcache
 import logging

--- a/ninfo/__init__.py
+++ b/ninfo/__init__.py
@@ -1,4 +1,9 @@
-from pkg_resources import iter_entry_points
+import sys
+
+if sys.version_info < (3, 10):
+    from importlib_metadata import entry_points
+else:
+    from importlib.metadata import entry_points
 
 __version__ = "1.0.1"
 
@@ -159,7 +164,7 @@ class Ninfo:
             self.plugin_modules = plugin_modules
         else:
             self.plugin_modules = {}
-            for ep in iter_entry_points(group="ninfo.plugin"):
+            for ep in entry_points(group="ninfo.plugin"):
                 self.plugin_modules[ep.name] = ep
 
         self.read_config(config_file)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ninfo"
-version = "1.0.0"
+version = "1.0.1"
 description = "Plugin based information gathering library"
 readme = "README.md"
 authors = [{ name = "Justin Azoff", email = "justin.azoff@gmail.com" }, { name = "Ryan Goggin", email = "support@ryangoggin.net" }]
@@ -35,7 +35,7 @@ Homepage = "https://github.com/ninfo-py/ninfo"
 ninfo = "ninfo:main"
 
 [tool.bumpver]
-current_version = "1.0.0"
+current_version = "1.0.1"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message  = "Bump version {old_version} -> {new_version}"
 commit          = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "python-memcached",
     "ieeemac",
     "IPy",
+    "importlib-metadata>=3.6.0; python_version < '3.10'",
 ]
 requires-python = ">=2.7"
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='ninfo',
-    version='1.0.0',
+    version='1.0.1',
     zip_safe=False,
     description="Plugin based information gathering library",
     packages = find_packages(exclude=["tests"]),

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(name='ninfo',
         "python-memcached",
         "ieeemac",
         "IPy",
+        "importlib-metadata>=3.6.0; python_version < '3.10'",
     ],
     extras_require = {
         'Splunk' : ['splunk-sdk'],


### PR DESCRIPTION
A deprecating warning for pkg_resources was added in [setuptools 67.5.0](https://github.com/pypa/setuptools/compare/v67.4.0...v67.5.0), and it has been [removed](https://github.com/pypa/setuptools/blob/main/docs/deprecated/pkg_resources.rst) as of setuptools 82.0.0.

> DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html

importlib.metadata.entry_points was "provisionally" added in Python 3.8, but it didn't accept keyword arguments (i.e., "group") until Python 3.10, so I used the [importlib_metadata](https://pypi.org/project/importlib-metadata/) backport for earlier Pythons.