### PR TITLE
Replace deprecated Splunk ResultsReader with JSONResultsReader

### DIFF
--- a/ninfo/__init__.py
+++ b/ninfo/__init__.py
@@ -1,6 +1,6 @@
 from pkg_resources import iter_entry_points
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 import memcache
 import logging

--- a/ninfo/helpers/splunk.py
+++ b/ninfo/helpers/splunk.py
@@ -44,7 +44,7 @@ class SplunkBase(PluginBase):
         self.connect()
         logger.debug("Searching splunk for '%s'" % query)
         q = "search " + query
-        rr = self.splunklibresults.ResultsReader(self.s.jobs.export(q))
+        rr = self.splunklibresults.JSONResultsReader(self.s.jobs.export(q, output_mode='json'))
         events = []
         for result in rr:
             if isinstance(result, self.splunklibresults.Message):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ninfo"
-version = "1.0.0"
+version = "1.0.1"
 description = "Plugin based information gathering library"
 readme = "README.md"
 authors = [{ name = "Justin Azoff", email = "justin.azoff@gmail.com" }, { name = "Ryan Goggin", email = "support@ryangoggin.net" }]
@@ -35,7 +35,7 @@ Homepage = "https://github.com/ninfo-py/ninfo"
 ninfo = "ninfo:main"
 
 [tool.bumpver]
-current_version = "1.0.0"
+current_version = "1.0.1"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message  = "Bump version {old_version} -> {new_version}"
 commit          = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requires-python = ">=2.7"
 
 [project.optional-dependencies]
 dev = ["black", "bumpver", "isort", "pip-tools", "pytest"]
-splunk = ["splunk-sdk"]
+splunk = ["splunk-sdk>=1.6.19"]
 
 [project.urls]
 Homepage = "https://github.com/ninfo-py/ninfo"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='ninfo',
-    version='1.0.0',
+    version='1.0.1',
     zip_safe=False,
     description="Plugin based information gathering library",
     packages = find_packages(exclude=["tests"]),

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(name='ninfo',
         "IPy",
     ],
     extras_require = {
-        'Splunk' : ['splunk-sdk'],
+        'Splunk' : ['splunk-sdk>=1.6.19'],
     },
     entry_points = {
         'console_scripts': [


### PR DESCRIPTION
> DeprecatedWarning: ResultsReader is deprecated. Use the JSONResultsReader function instead in conjuction with the 'output_mode' query param set to 'json'

JSONResultsReader was added and ResultsReader was deprecated in splunk-lib 1.6.19.  According to the [changelog](https://github.com/splunk/splunk-sdk-python/blob/develop/CHANGELOG.md#version-1619) it "[i]mproves performance by approx ~80-90%."